### PR TITLE
Update Dockerfile

### DIFF
--- a/autoscaler/Dockerfile
+++ b/autoscaler/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     curl \
     jq \
     docker.io \
+    docker-cli \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The autoscaler image failed to build because the Docker CLI binary was missing in the final stage. The builder stage installed only the docker.io package, which now ships daemon only. When the image tried to COPY /usr/bin/docker, the file was not present, causing the build to abort.